### PR TITLE
Fix typo in FeatureService

### DIFF
--- a/app/Services/FeatureService.php
+++ b/app/Services/FeatureService.php
@@ -3,7 +3,7 @@ namespace App\Services;
 
 use App\Models\Company;
 
-class FratureService
+class FeatureService
 {
     public function getFeatureValue(Company $company, string $featureKey): ?string
     {


### PR DESCRIPTION
## Summary
- rename `FratureService` to `FeatureService` and update class declaration

## Testing
- `composer test` *(fails: require vendor/autoload.php not found)*
- `composer install` *(fails: GitHub API 403, requires token)*

------
https://chatgpt.com/codex/tasks/task_e_68998dbde44883248fe9ac8070d6ad43