### PR TITLE
Restrict bulk actions to company

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -68,7 +68,9 @@ class CategoryController extends Controller
     public function bulkDelete(Request $request)
     {
         $ids = $request->input('ids', []);
-        Category::whereIn('id', $ids)->delete();
+        Category::where('company_id', auth()->user()->company_id)
+            ->whereIn('id', $ids)
+            ->delete();
 
         return back()->with('success', 'Categories deleted');
     }
@@ -78,7 +80,9 @@ class CategoryController extends Controller
         $ids = $request->input('ids', []);
         $status = $request->input('status');
 
-        Category::whereIn('id', $ids)->update(['status' => $status]);
+        Category::where('company_id', auth()->user()->company_id)
+            ->whereIn('id', $ids)
+            ->update(['status' => $status]);
 
         return back()->with('success', 'Status updated');
     }

--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -99,9 +99,11 @@ class OfferController extends Controller
     public function bulkDelete(Request $request)
     {
         $ids = $request->input('ids', []);
-        Offer::whereIn('id', $ids)->delete();
+        Offer::where('company_id', auth()->user()->company_id)
+            ->whereIn('id', $ids)
+            ->delete();
 
-        return back()->with('success', 'Categories deleted');
+        return back()->with('success', 'Offers deleted');
     }
 
     public function bulkStatus(Request $request)
@@ -109,25 +111,31 @@ class OfferController extends Controller
         $ids = $request->input('ids', []);
         $status = $request->input('status');
 
-        Offer::whereIn('id', $ids)->update(['status' => $status]);
+        Offer::where('company_id', auth()->user()->company_id)
+            ->whereIn('id', $ids)
+            ->update(['status' => $status]);
 
         return back()->with('success', 'Status updated');
     }
 
     public function bulkFeatured(Request $request)
     {
-        Offer::whereIn('id', $request->ids)->update([
-            'is_featured' => $request->status
-        ]);
+        Offer::where('company_id', auth()->user()->company_id)
+            ->whereIn('id', $request->ids)
+            ->update([
+                'is_featured' => $request->status,
+            ]);
 
         return redirect()->back()->with('success', 'Offers updated as featured.');
     }
 
     public function bulkExclusive(Request $request)
     {
-        Offer::whereIn('id', $request->ids)->update([
-            'is_exclusive' => $request->status
-        ]);
+        Offer::where('company_id', auth()->user()->company_id)
+            ->whereIn('id', $request->ids)
+            ->update([
+                'is_exclusive' => $request->status,
+            ]);
 
         return redirect()->back()->with('success', 'Offers updated as exclusive.');
     }

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -49,9 +49,11 @@ class StoreController extends Controller
     public function bulkDelete(Request $request)
     {
         $ids = $request->input('ids', []);
-        Store::whereIn('id', $ids)->delete();
+        Store::where('company_id', auth()->user()->company_id)
+            ->whereIn('id', $ids)
+            ->delete();
 
-        return back()->with('success', 'Categories deleted');
+        return back()->with('success', 'Stores deleted');
     }
 
     public function bulkStatus(Request $request)
@@ -59,7 +61,9 @@ class StoreController extends Controller
         $ids = $request->input('ids', []);
         $status = $request->input('status');
 
-        Store::whereIn('id', $ids)->update(['status' => $status]);
+        Store::where('company_id', auth()->user()->company_id)
+            ->whereIn('id', $ids)
+            ->update(['status' => $status]);
 
         return back()->with('success', 'Status updated');
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,8 +87,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/company/addrevenue/getProducts', [AddrevenueController::class, 'getProducts']);
     Route::post('/categories/bulk-delete', [CategoryController::class, 'bulkDelete'])->name('categories.bulkDelete');
     Route::post('/categories/bulk-status', [CategoryController::class, 'bulkStatus'])->name('categories.bulkStatus');
-    Route::post('/stores/bulk-delete', [StoreController::class, 'bulkDelete'])->name('categories.bulkDelete');
-    Route::post('/stores/bulk-status', [StoreController::class, 'bulkStatus'])->name('categories.bulkStatus');
+    Route::post('/stores/bulk-delete', [StoreController::class, 'bulkDelete'])->name('stores.bulkDelete');
+    Route::post('/stores/bulk-status', [StoreController::class, 'bulkStatus'])->name('stores.bulkStatus');
     Route::post('/offers/bulk-delete', [OfferController::class, 'bulkDelete'])->name('offers.bulkDelete');
     Route::post('/offers/bulk-status', [OfferController::class, 'bulkStatus'])->name('offers.bulkStatus');
     Route::post('/offers/bulk-featured', [OfferController::class, 'bulkFeatured']);

--- a/tests/Feature/BulkActionTest.php
+++ b/tests/Feature/BulkActionTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Store;
+use App\Models\Offer;
+use App\Models\User;
+use Tests\TestCase;
+
+class BulkActionTest extends TestCase
+{
+    /** @test */
+    public function offer_bulk_delete_is_limited_to_authenticated_users_company(): void
+    {
+        $companyA = Company::create([
+            'name' => 'Company A',
+            'email' => 'a@example.com',
+            'domain' => 'a.com',
+            'registration_no' => 'regA',
+            'vat' => 'vatA',
+            'status' => 1,
+        ]);
+        $companyB = Company::create([
+            'name' => 'Company B',
+            'email' => 'b@example.com',
+            'domain' => 'b.com',
+            'registration_no' => 'regB',
+            'vat' => 'vatB',
+            'status' => 1,
+        ]);
+
+        $storeA = Store::create([
+            'company_id' => $companyA->id,
+            'name' => 'Store A',
+        ]);
+        $storeB = Store::create([
+            'company_id' => $companyB->id,
+            'name' => 'Store B',
+        ]);
+
+        $offerA = Offer::create([
+            'company_id' => $companyA->id,
+            'store_id' => $storeA->id,
+            'title' => 'Offer A',
+        ]);
+        $offerB = Offer::create([
+            'company_id' => $companyB->id,
+            'store_id' => $storeB->id,
+            'title' => 'Offer B',
+        ]);
+
+        $user = User::factory()->create(['company_id' => $companyA->id]);
+
+        $this->actingAs($user)
+            ->post(route('offers.bulkDelete'), ['ids' => [$offerA->id, $offerB->id]])
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('offers', ['id' => $offerA->id]);
+        $this->assertDatabaseHas('offers', ['id' => $offerB->id]);
+    }
+
+    /** @test */
+    public function store_bulk_status_only_updates_records_for_users_company(): void
+    {
+        $companyA = Company::create([
+            'name' => 'Company A',
+            'email' => 'a@example.com',
+            'domain' => 'a.com',
+            'registration_no' => 'regA',
+            'vat' => 'vatA',
+            'status' => 1,
+        ]);
+        $companyB = Company::create([
+            'name' => 'Company B',
+            'email' => 'b@example.com',
+            'domain' => 'b.com',
+            'registration_no' => 'regB',
+            'vat' => 'vatB',
+            'status' => 1,
+        ]);
+
+        $storeA = Store::create([
+            'company_id' => $companyA->id,
+            'name' => 'Store A',
+            'status' => 1,
+        ]);
+        $storeB = Store::create([
+            'company_id' => $companyB->id,
+            'name' => 'Store B',
+            'status' => 1,
+        ]);
+
+        $user = User::factory()->create(['company_id' => $companyA->id]);
+
+        $this->actingAs($user)
+            ->post(route('stores.bulkStatus'), ['ids' => [$storeA->id, $storeB->id], 'status' => 2])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('stores', ['id' => $storeA->id, 'status' => 2]);
+        $this->assertDatabaseHas('stores', ['id' => $storeB->id, 'status' => 1]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- scope bulk store/offer/category updates to the authenticated user's company
- fix misnamed store bulk routes and messages
- add feature tests for bulk action company scoping

## Testing
- `php artisan test` *(fails: Failed to open stream: No such file or directory: vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68998b47a9548324be8cc77c84474b89