### PR TITLE
Handle missing category when syncing Addrevenue products

### DIFF
--- a/app/Jobs/SyncAddrevenueProductsJob.php
+++ b/app/Jobs/SyncAddrevenueProductsJob.php
@@ -106,7 +106,9 @@ class SyncAddrevenueProductsJob implements ShouldQueue
             ]);
             $deal->store()->associate($store->id);
             $deal->company()->associate($this->companyId);
-            $deal->category()->associate($categoryId);
+            if ($categoryId !== null) {
+                $deal->category()->associate($categoryId);
+            }
 
             try {
                 $deal->save();
@@ -120,8 +122,11 @@ class SyncAddrevenueProductsJob implements ShouldQueue
 
     public function getCategory($store)
     {
-        return Category::query()
+        $category = Category::query()
             ->where('company_id', $this->companyId)
-            ->where('name',$store->categoryName)->first()->id;
+            ->where('name', $store->categoryName)
+            ->first();
+
+        return $category?->id;
     }
 }


### PR DESCRIPTION
## Summary
- Avoid null dereference when fetching categories in `SyncAddrevenueProductsJob`
- Only associate deals with categories when a match exists

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: Failed to download pestphp/pest-plugin from dist: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899925866c08324b7c7f68570ec8337