### PR TITLE
feat: add role-based dashboard stats

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+use App\Models\Company;
+use App\Models\Offer;
+use App\Models\Store;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class DashboardController extends Controller
+{
+    /**
+     * Display the dashboard with counts based on user type.
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        if ($user->company_id) {
+            $companyId = $user->company_id;
+
+            $data = [
+                'type' => 'company',
+                'counts' => [
+                    'offers' => Offer::where('company_id', $companyId)->count(),
+                    'categories' => Category::where('company_id', $companyId)->count(),
+                    'stores' => Store::where('company_id', $companyId)->count(),
+                ],
+            ];
+        } else {
+            $data = [
+                'type' => 'admin',
+                'counts' => [
+                    'companies' => Company::count(),
+                    'offers' => Offer::count(),
+                    'categories' => Category::count(),
+                    'stores' => Store::count(),
+                ],
+            ];
+        }
+
+        return Inertia::render('Dashboard', $data);
+    }
+}

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -2,7 +2,12 @@
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/vue3';
-import PlaceholderPattern from '../components/PlaceholderPattern.vue';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    type: string;
+    counts: Record<string, number>;
+}>();
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -10,6 +15,8 @@ const breadcrumbs: BreadcrumbItem[] = [
         href: '/dashboard',
     },
 ];
+
+const stats = computed(() => Object.entries(props.counts));
 </script>
 
 <template>
@@ -18,18 +25,16 @@ const breadcrumbs: BreadcrumbItem[] = [
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
             <div class="grid auto-rows-min gap-4 md:grid-cols-3">
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
+                <div
+                    v-for="[label, value] in stats"
+                    :key="label"
+                    class="relative flex flex-col items-center justify-center overflow-hidden rounded-xl border border-sidebar-border/70 p-4 text-center dark:border-sidebar-border"
+                >
+                    <div class="text-2xl font-bold">{{ value }}</div>
+                    <div class="mt-2 capitalize text-muted-foreground">
+                        {{ label.replace('_', ' ') }}
+                    </div>
                 </div>
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-            </div>
-            <div class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
-                <PlaceholderPattern />
             </div>
         </div>
     </AppLayout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\CompanyController;
 use App\Http\Controllers\CompanyFrontendSettingsController;
 use App\Http\Controllers\CompanyIntegrationController;
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\OfferController;
@@ -40,9 +41,9 @@ Route::get('/blog', function () {
 Route::get('/contact', function () {
     return Inertia::render('Contact');
 })->name('contact');
-Route::get('dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('dashboard', [DashboardController::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('dashboard');
 Route::get('/subscriptions/checkout', function () {
     return redirect()->route('home');
 });

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,6 +1,11 @@
 <?php
 
 use App\Models\User;
+use App\Models\Company;
+use App\Models\Category;
+use App\Models\Store;
+use App\Models\Offer;
+use Inertia\Testing\AssertableInertia as Assert;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -15,4 +20,58 @@ test('authenticated users can visit the dashboard', function () {
 
     $response = $this->get('/dashboard');
     $response->assertStatus(200);
+});
+
+test('super admins see global counts', function () {
+    $user = User::factory()->create();
+
+    $company1 = Company::create(['name' => 'Company One', 'email' => 'c1@example.com']);
+    $company2 = Company::create(['name' => 'Company Two', 'email' => 'c2@example.com']);
+
+    $store1 = Store::create(['name' => 'Store One', 'company_id' => $company1->id]);
+    $store2 = Store::create(['name' => 'Store Two', 'company_id' => $company2->id]);
+
+    Category::create(['name' => 'Cat One', 'company_id' => $company1->id]);
+    Category::create(['name' => 'Cat Two', 'company_id' => $company2->id]);
+
+    Offer::create(['title' => 'Offer One', 'company_id' => $company1->id, 'store_id' => $store1->id]);
+    Offer::create(['title' => 'Offer Two', 'company_id' => $company2->id, 'store_id' => $store2->id]);
+
+    $this->actingAs($user);
+
+    $response = $this->get('/dashboard');
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->where('type', 'admin')
+        ->where('counts.companies', 2)
+        ->where('counts.categories', 2)
+        ->where('counts.stores', 2)
+        ->where('counts.offers', 2)
+    );
+});
+
+test('company users see company counts', function () {
+    $company1 = Company::create(['name' => 'Company One', 'email' => 'c1@example.com']);
+    $company2 = Company::create(['name' => 'Company Two', 'email' => 'c2@example.com']);
+
+    $store1 = Store::create(['name' => 'Store One', 'company_id' => $company1->id]);
+    $store2 = Store::create(['name' => 'Store Two', 'company_id' => $company2->id]);
+
+    Category::create(['name' => 'Cat One', 'company_id' => $company1->id]);
+    Category::create(['name' => 'Cat Two', 'company_id' => $company2->id]);
+
+    Offer::create(['title' => 'Offer One', 'company_id' => $company1->id, 'store_id' => $store1->id]);
+    Offer::create(['title' => 'Offer Two', 'company_id' => $company2->id, 'store_id' => $store2->id]);
+
+    $user = User::factory()->create(['company_id' => $company1->id]);
+    $this->actingAs($user);
+
+    $response = $this->get('/dashboard');
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->where('type', 'company')
+        ->where('counts.categories', 1)
+        ->where('counts.stores', 1)
+        ->where('counts.offers', 1)
+    );
 });


### PR DESCRIPTION
## Summary
- add DashboardController with company/admin stat logic
- wire up dashboard route and display counts on Dashboard.vue
- cover admin and company dashboards with tests

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars in unrelated files)*
- `composer test` *(fails: vendor dependencies missing and composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_6899e1b55a0c8324b42b743600bbe633